### PR TITLE
Update repo.sh for rpm version change

### DIFF
--- a/scripts/centos-7.2/repo.sh
+++ b/scripts/centos-7.2/repo.sh
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
 sudo sed -i -e 's/^enabled=1/enabled=0/' /etc/yum.repos.d/epel.repo


### PR DESCRIPTION
Hi, the original `epel-release-7-5.noarch.rpm` was updated to `epel-release-7-6.noarch.rpm`, which causes the following packer error:

```
==> vmware-iso: Provisioning with shell script: scripts/centos-7.2/repo.sh
    vmware-iso: + sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
    vmware-iso: Loaded plugins: fastestmirror
    vmware-iso: Cannot open: https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm. Skipping.
    vmware-iso: Error: Nothing to do
==> vmware-iso: Stopping virtual machine...
```

This changes fixes the problem