### PR TITLE
Upgrades epel repository to version 7.9

### DIFF
--- a/scripts/centos-7.3/repo.sh
+++ b/scripts/centos-7.3/repo.sh
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+sudo yum -y install https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 sudo sed -i -e 's/^enabled=1/enabled=0/' /etc/yum.repos.d/epel.repo


### PR DESCRIPTION
This Url is no longer available (404) https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
This Url works: https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm