### PR TITLE
Adding OpenBSD 6.2

### DIFF
--- a/http/openbsd-6.2/install-chroot.sh
+++ b/http/openbsd-6.2/install-chroot.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+set -x
+
+pkg_add sudo--
+cat <<EOF > /etc/sudoers
+
+#includedir /etc/sudoers.d
+EOF
+mkdir /etc/sudoers.d
+cat <<EOF > /etc/sudoers.d/vagrant
+Defaults:vagrant !requiretty
+vagrant ALL=(ALL) NOPASSWD: ALL
+EOF
+chmod 440 /etc/sudoers.d/vagrant

--- a/http/openbsd-6.2/install.conf
+++ b/http/openbsd-6.2/install.conf
@@ -1,0 +1,9 @@
+System hostname = vagrantup.com
+Password for root account = vagrant
+Do you expect to run the X Window System = no
+Setup a user = vagrant
+Password for user vagrant = vagrant
+Location of sets = http
+Set name(s) = -game*
+Set name(s) = -x*
+What timezone are you in = Etc/UTC

--- a/http/openbsd-6.2/install.sh
+++ b/http/openbsd-6.2/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# Always use the first line of ftplist.cgi for the default answer of "HTTP Server?".
+# This is a workaround for the change introduced in the following commit:
+# https://github.com/openbsd/src/commit/bf983825822b119e4047eb99486f18c58351f347
+sed -i'' 's/\[\[ -z $_l \]\] && //' /install.sub
+
+/install -a -f /install.conf && chroot /mnt

--- a/openbsd-6.2-amd64.json
+++ b/openbsd-6.2-amd64.json
@@ -1,0 +1,113 @@
+{
+  "builders": [{
+    "type": "qemu",
+    "iso_url": "{{user `mirror`}}/6.2/amd64/cd62.iso",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "output_directory": "output-openbsd-6.2-amd64-{{build_type}}",
+    "vm_name": "packer-openbsd-6.2-amd64",
+    "disk_size": "{{user `disk_size`}}",
+    "headless": "{{user `headless`}}",
+    "http_directory": "http",
+    "boot_wait": "20s",
+    "boot_command": [
+      "S<enter><wait>",
+      "dhclient vio0<enter><wait>",
+      "ftp -o install.conf http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install.conf<enter><wait>",
+      "ftp -o install.sh http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install.sh<enter><wait>",
+      "ftp -o install-chroot.sh http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install-chroot.sh<enter><wait>",
+      "sh install.sh < install-chroot.sh && reboot<enter>"
+    ],
+    "ssh_timeout": "{{user `ssh_timeout`}}",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "shutdown_command": "sudo shutdown -h -p now",
+    "qemuargs": [
+      ["-m", "{{user `memory`}}"],
+      ["-smp", "{{user `cpus`}}"]
+    ]
+  }, {
+    "type": "virtualbox-iso",
+    "guest_os_type": "OpenBSD_64",
+    "iso_url": "{{user `mirror`}}/6.2/amd64/cd62.iso",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "output_directory": "output-openbsd-6.2-amd64-{{build_type}}",
+    "vm_name": "packer-openbsd-6.2-amd64",
+    "disk_size": "{{user `disk_size`}}",
+    "headless": "{{user `headless`}}",
+    "http_directory": "http",
+    "boot_wait": "20s",
+    "boot_command": [
+      "S<enter><wait>",
+      "dhclient em0<enter><wait>",
+      "ftp -o install.conf http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install.conf<enter><wait>",
+      "ftp -o install.sh http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install.sh<enter><wait>",
+      "ftp -o install-chroot.sh http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install-chroot.sh<enter><wait>",
+      "sh install.sh < install-chroot.sh && reboot<enter>"
+    ],
+    "ssh_timeout": "{{user `ssh_timeout`}}",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "guest_additions_mode": "disable",
+    "shutdown_command": "sudo shutdown -h -p now",
+    "vboxmanage": [
+      ["modifyvm", "{{.Name}}", "--memory", "{{user `memory`}}"],
+      ["modifyvm", "{{.Name}}", "--cpus", "{{user `cpus`}}"]
+    ]
+  }, {
+    "type": "vmware-iso",
+    "guest_os_type": "freebsd-64",
+    "iso_url": "{{user `mirror`}}/6.2/amd64/cd62.iso",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "output_directory": "output-openbsd-6.2-amd64-{{build_type}}",
+    "vm_name": "packer-openbsd-6.2-amd64",
+    "disk_size": "{{user `disk_size`}}",
+    "headless": "{{user `headless`}}",
+    "http_directory": "http",
+    "boot_wait": "20s",
+    "boot_command": [
+      "S<enter><wait>",
+      "dhclient em0<enter><wait>",
+      "ftp -o install.conf http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install.conf<enter><wait>",
+      "ftp -o install.sh http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install.sh<enter><wait>",
+      "ftp -o install-chroot.sh http://{{.HTTPIP}}:{{.HTTPPort}}/openbsd-6.2/install-chroot.sh<enter><wait>",
+      "sh install.sh < install-chroot.sh && reboot<enter>"
+    ],
+    "ssh_timeout": "{{user `ssh_timeout`}}",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "shutdown_command": "sudo shutdown -h -p now",
+    "vmx_data": {
+      "memsize": "{{user `memory`}}",
+      "numvcpus": "{{user `cpus`}}"
+    }
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "scripts": [
+      "scripts/openbsd/init.sh",
+      "scripts/common/vagrant.sh",
+      "scripts/common/sshd.sh",
+      "scripts/openbsd/minimize.sh"
+    ]
+  }],
+  "post-processors": [{
+    "type": "vagrant",
+    "compression_level": "{{user `compression_level`}}",
+    "output": "openbsd-6.2-amd64-{{.Provider}}.box",
+    "vagrantfile_template": "vagrantfile_templates/openbsd.rb"
+  }],
+  "variables": {
+    "compression_level": "6",
+    "cpus": "1",
+    "disk_size": "100000",
+    "headless": "false",
+    "iso_checksum": "e66b406cf5775c934b04eb2c3af1f8f6f4704f67445b2dd22916a7b962a74667",
+    "iso_checksum_type": "sha256",
+    "memory": "512",
+    "mirror": "http://ftp.openbsd.org/pub/OpenBSD",
+    "ssh_timeout": "60m"
+  }
+}

--- a/scripts/openbsd/init.sh
+++ b/scripts/openbsd/init.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-sudo pkg_add curl
+sudo pkg_add curl python-2.7.14
 
 sudo tee /etc/rc.conf.local <<EOF
 sndiod_flags=NO


### PR DESCRIPTION
This should close Issue #24 and add support for OpenBSD with a proper checksum.  The only possibly contentious part is the addition of Python in the default install.  I added it because every step I attempted past the initial installation required it.