### PR TITLE
fedora: install nfs-utils for libvirt to mount shared folders

### DIFF
--- a/fedora-28-x86_64.json
+++ b/fedora-28-x86_64.json
@@ -85,6 +85,7 @@
     "type": "shell",
     "scripts": [
       "scripts/fedora/virtualbox.sh",
+      "scripts/fedora/qemu.sh",
       "scripts/fedora/vmware.sh",
       "scripts/common/vagrant.sh",
       "scripts/common/sshd.sh",

--- a/scripts/fedora/qemu.sh
+++ b/scripts/fedora/qemu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ "$PACKER_BUILDER_TYPE" != "qemu" ]; then
+  exit 0
+fi
+
+sudo dnf -y install nfs-utils


### PR DESCRIPTION
Otherwise it fails when trying to restart rpcbind and nfs services.