### PR TITLE
Debian Update to 9.5.0

### DIFF
--- a/debian-9.5-amd64.json
+++ b/debian-9.5-amd64.json
@@ -4,8 +4,8 @@
     "iso_url": "{{user `mirror`}}/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
-    "output_directory": "output-debian-9.4-amd64-{{build_type}}",
-    "vm_name": "packer-debian-9.4-amd64",
+    "output_directory": "output-debian-9.5-amd64-{{build_type}}",
+    "vm_name": "packer-debian-9.5-amd64",
     "disk_size": "{{user `disk_size`}}",
     "headless": "{{user `headless`}}",
     "http_directory": "http",
@@ -14,7 +14,7 @@
       "<esc><wait>",
       "auto ",
       "net.ifnames=0 ",
-      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/debian-9.4/preseed.cfg ",
+      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/debian-9.5/preseed.cfg ",
       "<enter>"
     ],
     "ssh_timeout": "{{user `ssh_timeout`}}",
@@ -31,8 +31,8 @@
     "iso_url": "{{user `mirror`}}/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
-    "output_directory": "output-debian-9.4-amd64-{{build_type}}",
-    "vm_name": "packer-debian-9.4-amd64",
+    "output_directory": "output-debian-9.5-amd64-{{build_type}}",
+    "vm_name": "packer-debian-9.5-amd64",
     "disk_size": "{{user `disk_size`}}",
     "headless": "{{user `headless`}}",
     "http_directory": "http",
@@ -41,7 +41,7 @@
       "<esc><wait>",
       "auto ",
       "net.ifnames=0 ",
-      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/debian-9.4/preseed.cfg ",
+      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/debian-9.5/preseed.cfg ",
       "<enter>"
     ],
     "ssh_timeout": "{{user `ssh_timeout`}}",
@@ -58,8 +58,8 @@
     "iso_url": "{{user `mirror`}}/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
-    "output_directory": "output-debian-9.4-amd64-{{build_type}}",
-    "vm_name": "packer-debian-9.4-amd64",
+    "output_directory": "output-debian-9.5-amd64-{{build_type}}",
+    "vm_name": "packer-debian-9.5-amd64",
     "disk_size": "{{user `disk_size`}}",
     "headless": "{{user `headless`}}",
     "http_directory": "http",
@@ -68,7 +68,7 @@
       "<esc><wait>",
       "auto ",
       "net.ifnames=0 ",
-      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/debian-9.4/preseed.cfg ",
+      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/debian-9.5/preseed.cfg ",
       "<enter>"
     ],
     "ssh_timeout": "{{user `ssh_timeout`}}",
@@ -85,7 +85,7 @@
     "type": "shell",
     "scripts": [
       "scripts/debian/virtualbox.sh",
-      "scripts/debian-9.4/vmware.sh",
+      "scripts/debian-9.5/vmware.sh",
       "scripts/common/vagrant.sh",
       "scripts/common/sshd.sh",
       "scripts/debian/cleanup.sh",
@@ -95,7 +95,7 @@
   "post-processors": [{
     "type": "vagrant",
     "compression_level": "{{user `compression_level`}}",
-    "output": "debian-9.4-amd64-{{.Provider}}.box"
+    "output": "debian-9.5-amd64-{{.Provider}}.box"
   }],
   "variables": {
     "compression_level": "6",

--- a/debian-9.5-amd64.json
+++ b/debian-9.5-amd64.json
@@ -1,7 +1,7 @@
  {
   "builders": [{
     "type": "qemu",
-    "iso_url": "{{user `mirror`}}/9.4.0/amd64/iso-cd/debian-9.4.0-amd64-netinst.iso",
+    "iso_url": "{{user `mirror`}}/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-debian-9.4-amd64-{{build_type}}",
@@ -28,7 +28,7 @@
   }, {
     "type": "virtualbox-iso",
     "guest_os_type": "Debian_64",
-    "iso_url": "{{user `mirror`}}/9.4.0/amd64/iso-cd/debian-9.4.0-amd64-netinst.iso",
+    "iso_url": "{{user `mirror`}}/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-debian-9.4-amd64-{{build_type}}",
@@ -55,7 +55,7 @@
   }, {
     "type": "vmware-iso",
     "guest_os_type": "debian8-64",
-    "iso_url": "{{user `mirror`}}/9.4.0/amd64/iso-cd/debian-9.4.0-amd64-netinst.iso",
+    "iso_url": "{{user `mirror`}}/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-debian-9.4-amd64-{{build_type}}",
@@ -102,7 +102,7 @@
     "cpus": "1",
     "disk_size": "40000",
     "headless": "false",
-    "iso_checksum": "124d270006703f2111224dec3bf7a9d01450168be41d4834f88fdd035552b044",
+    "iso_checksum": "1f97a4b8dee7c3def5cd8215ff01b9edef27c901b28fa8b1ef4f022eff7c36c2",
     "iso_checksum_type": "sha256",
     "memory": "512",
     "mirror": "http://cdimage.debian.org/debian-cd",


### PR DESCRIPTION
Removed the file for Debian 9.4.0 since it 404'd on the packer build. Updated the code to support Debian 9.5.0.